### PR TITLE
Future-proof against addition of Data.List.!?

### DIFF
--- a/library/YamlUnscrambler/Util/Vector.hs
+++ b/library/YamlUnscrambler/Util/Vector.hs
@@ -1,8 +1,8 @@
 module YamlUnscrambler.Util.Vector where
 
-import Data.Vector
+import Data.Vector as V
 import YamlUnscrambler.Prelude as Prelude hiding (lookup)
 
 lookupFirst :: [Int] -> Vector a -> Maybe (Int, a)
 lookupFirst keys vector =
-  getFirst (Prelude.foldMap (\k -> First (fmap (k,) (vector !? k))) keys)
+  getFirst (Prelude.foldMap (\k -> First (fmap (k,) (vector V.!? k))) keys)


### PR DESCRIPTION
`base-4.19` (and GHC 9.8) will export `Data.List.!?`, which will cause a name clash with `Data.Vector.!?` in 
https://github.com/nikita-volkov/yaml-unscrambler/blob/547a4f8add3bf888e08cd7b5957dd61039c46fde/library/YamlUnscrambler/Util/Vector.hs#L3-L8

This PR qualifies `!?` to make it unambiguous. 

See https://github.com/haskell/core-libraries-committee/issues/110#issuecomment-1359037078 for CLC discussion of the change.